### PR TITLE
Diff from base_rev instead of main

### DIFF
--- a/taskcluster/kinds/diff-from-lobby/kind.yml
+++ b/taskcluster/kinds/diff-from-lobby/kind.yml
@@ -2,6 +2,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
   - src.transforms.lobby_diff:transforms
+  - taskgraph.transforms.task_context
   - src.transforms.github:transforms
   - taskgraph.transforms.run:transforms
   - taskgraph.transforms.task:transforms
@@ -23,18 +24,23 @@ tasks:
     scopes:
       - github:create-comment:Eijebong/Archipelago-index
       - secrets:get:ap-lobby
+    task-context:
+      from-parameters:
+        base_rev: base_rev
+      substitution-fields:
+        - run.command
     run:
       using: run-task
       command: >-
         cd $VCS_PATH &&
         mkdir -p /builds/worker/diffs &&
-        echo 'LOBBY_API_KEY=$(curl -q "${TASKCLUSTER_PROXY_URL}/secrets/v1/secret/ap-lobby" | jq -r ".secret.admin_key_prod") apwm diff -i ./ -f https://github.com/Eijebong/Archipelago-index -o /builds/worker/diffs -l https://ap-lobby.bananium.fr' > diff.sh &&
+        echo 'LOBBY_API_KEY=$(curl -q "${{TASKCLUSTER_PROXY_URL}}/secrets/v1/secret/ap-lobby" | jq -r ".secret.admin_key_prod") apwm diff -i ./ -f https://github.com/Eijebong/Archipelago-index -r {{base_rev}} -o /builds/worker/diffs -l https://ap-lobby.bananium.fr' > diff.sh &&
         bash diff.sh
         &&
         (
           [ -z "$( ls -A '/builds/worker/diffs' )" ] &&
-          /usr/bin/curl --header "Content-Type: application/json" ${TASKCLUSTER_PROXY_URL}/github/v1/repository/Eijebong/Archipelago-index/issues/${GITHUB_PR}/comments --data "{\"body\": \"No reviewable changes\"}" ||
-          /usr/bin/curl --header "Content-Type: application/json" ${TASKCLUSTER_PROXY_URL}/github/v1/repository/Eijebong/Archipelago-index/issues/${GITHUB_PR}/comments --data "{\"body\": \"[Review changes](https://apdiff.bananium.fr/${TASK_ID})\"}"
+          /usr/bin/curl --header "Content-Type: application/json" ${{TASKCLUSTER_PROXY_URL}}/github/v1/repository/Eijebong/Archipelago-index/issues/${{GITHUB_PR}}/comments --data "{{\"body\": \"No reviewable changes\"}}" ||
+          /usr/bin/curl --header "Content-Type: application/json" ${{TASKCLUSTER_PROXY_URL}}/github/v1/repository/Eijebong/Archipelago-index/issues/${{GITHUB_PR}}/comments --data "{{\"body\": \"[Review changes](https://apdiff.bananium.fr/${{TASK_ID}})\"}}"
         )
     worker:
       artifacts:

--- a/taskcluster/kinds/diff/kind.yml
+++ b/taskcluster/kinds/diff/kind.yml
@@ -1,11 +1,13 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+  - taskgraph.transforms.task_context
   - src.transforms.github:transforms
   - src.transforms.github_cached:transforms
   - taskgraph.transforms.run:transforms
   - taskgraph.transforms.task:transforms
   - eije_taskgraph.transforms.common:transforms
+
 task-defaults:
   worker:
     docker-image: ghcr.io/eijebong/apwm:latest
@@ -24,16 +26,21 @@ tasks:
     description: Run apwm diff
     scopes:
       - github:create-comment:Eijebong/Archipelago-index
+    task-context:
+      from-parameters:
+        base_rev: base_rev
+      substitution-fields:
+        - run.command
     run:
       using: run-task
       command: >-
         cd $VCS_PATH &&
         mkdir -p /builds/worker/diffs &&
-        apwm diff -i ./ -f https://github.com/Eijebong/Archipelago-index -o /builds/worker/diffs &&
+        apwm diff -i ./ -f https://github.com/Eijebong/Archipelago-index -r {base_rev} -o /builds/worker/diffs &&
         (
           [ -z "$( ls -A '/builds/worker/diffs' )" ] &&
-          /usr/bin/curl --header "Content-Type: application/json" ${TASKCLUSTER_PROXY_URL}/github/v1/repository/Eijebong/Archipelago-index/issues/${GITHUB_PR}/comments --data "{\"body\": \"No reviewable changes\"}" ||
-          /usr/bin/curl --header "Content-Type: application/json" ${TASKCLUSTER_PROXY_URL}/github/v1/repository/Eijebong/Archipelago-index/issues/${GITHUB_PR}/comments --data "{\"body\": \"[Review changes](https://apdiff.bananium.fr/${TASK_ID})\"}"
+          /usr/bin/curl --header "Content-Type: application/json" ${{TASKCLUSTER_PROXY_URL}}/github/v1/repository/Eijebong/Archipelago-index/issues/${{GITHUB_PR}}/comments --data "{{\"body\": \"No reviewable changes\"}}" ||
+          /usr/bin/curl --header "Content-Type: application/json" ${{TASKCLUSTER_PROXY_URL}}/github/v1/repository/Eijebong/Archipelago-index/issues/${{GITHUB_PR}}/comments --data "{{\"body\": \"[Review changes](https://apdiff.bananium.fr/${{TASK_ID}})\"}}"
         )
     worker:
       artifacts:


### PR DESCRIPTION
Because `task-context` ultimately calls `.format` we have to escape all `{}` except for the ones we want it to actually format.