### PR TITLE
Add missing mm2

### DIFF
--- a/index/mm2.toml
+++ b/index/mm2.toml
@@ -1,0 +1,3 @@
+name = "Mega Man 2"
+home = "https://archipelago.gg"
+supported = true


### PR DESCRIPTION
I'm not entirely sure how it got forgotten in the 0.5.1 update given `scripts/add_supported.sh` created the file properly...