### PR TITLE
Update Megamix

### DIFF
--- a/index/megamix.toml
+++ b/index/megamix.toml
@@ -6,4 +6,4 @@ default_url = "https://github.com/Cynichill/DivaAPworld/releases/download/{{vers
 # 1.0.6B with https://github.com/RePod/DivaAPworld-R/blob/ce18682c57644344de2a86962d0315c689fb00e9/diffs/early/0_mod_folder.diff
 "1.0.6-beta" = { local = "../apworlds/megamix-1.0.6-beta.patched.apworld" }
 "1.1.4-beta-unofficial" = { url = "https://github.com/RePod/DivaAPworld-R/releases/download/1.1.4B-R_241127-b6fccc5/megamix.apworld" }
-"1.1.9-beta-unofficial" = { url = "https://github.com/RePod/DivaAPworld-R/releases/download/1.1.9B-R_250225-16f3165/megamix.apworld" }
+"1.1.9-beta-unofficial" = { url = "https://github.com/RePod/DivaAPworld-R/releases/download/1.1.9B-R_250306-a0c4577/megamix.apworld" }


### PR DESCRIPTION
Unofficial 1.1.9 + diffed https://github.com/Cynichill/DivaAPworld/pull/23 (mostly Client side) and https://github.com/Cynichill/DivaAPworld/pull/28 (fuzz proofing)
This also includes the smaller JSON.