### PR TITLE
Lethal Company version bump

### DIFF
--- a/index/lethal_company.toml
+++ b/index/lethal_company.toml
@@ -5,3 +5,4 @@ default_url = "https://github.com/T0r1nn/APLC/releases/download/{{version}}/leth
 [versions]
 "0.6.9-beta" = {}
 "0.6.13-beta" = {}
+"0.7.1-beta" = { url = "https://github.com/T0r1nn/APLC/releases/download/v0.7.1-beta/lethal_company.apworld" }


### PR DESCRIPTION
newest release suddenly had a "v" as prefix for release version