### PR TITLE
Re-add YuGiOh2006 beta


### DIFF
--- a/index/yugioh06.toml
+++ b/index/yugioh06.toml
@@ -1,3 +1,6 @@
 name = "Yu-Gi-Oh! 2006"
 home = "https://archipelago.gg"
 supported = true
+
+[versions]
+"2.4.0-beta" = { url = "https://github.com/Rensen3/ArchipelagoYGO06/releases/download/YuGiOh2006v2.4/yugioh06.apworld" }


### PR DESCRIPTION

I removed it during the 0.6.1 update assuming that the changes in there
had been merged.