### PR TITLE
Re-add Yacht Dice 2.2.2 beta

### DIFF
--- a/index/yachtdice.toml
+++ b/index/yachtdice.toml
@@ -1,3 +1,6 @@
 name = "Yacht Dice"
 home = "https://archipelago.gg"
 supported = true
+
+[versions]
+"2.2.2-testing" = { url = "https://github.com/spinerak/ArchipelagoYachtDice/releases/download/v2.2.2/yachtdice.apworld" }


### PR DESCRIPTION
The 2.2.2 beta was removed in the update to AP 0.6.1, but the 2.2.2 beta is ahead of the AP 0.6.1 release of Yacht Dice.

If it was removed for other reasons, I was not aware of them.