### PR TITLE
Update earthbound and yank busted version

### DIFF
--- a/index/earthbound.toml
+++ b/index/earthbound.toml
@@ -5,4 +5,4 @@ home = "https://discord.com/channels/731205301247803413/1077266688657068032"
 "3.2.0" = { url = "https://github.com/PinkSwitch/Archipelago/releases/download/earthboundap3.2/earthbound.apworld" }
 "3.3.1" = { url = "https://github.com/PinkSwitch/Archipelago/releases/download/earthboundap3.3.1/earthbound.apworld" }
 "3.5.0" = { url = "https://github.com/PinkSwitch/Archipelago/releases/download/earthboundap3.5/earthbound.apworld" }
-"4.0.0" = { url = "https://github.com/PinkSwitch/Archipelago/releases/download/earthboundap4.0/earthbound.apworld" }
+"4.0.1" = { url = "https://github.com/PinkSwitch/Archipelago/releases/download/earthboundap4.0.1/earthbound.apworld" }


### PR DESCRIPTION
4.0.0 doesn't generate at all if there's more than one earthbound in the multiworld, let's not keep it around