### PR TITLE
Add Celeste (Open World)

### DIFF
--- a/index/celeste_open_world.toml
+++ b/index/celeste_open_world.toml
@@ -1,0 +1,6 @@
+name = "Celeste (Open World)"
+home = "https://discord.com/channels/731205301247803413/1364797357958631434"
+default_url = "https://github.com/PoryGoneDev/Celeste-Archipelago-Open-World/releases/download/v{{version}}/celeste_open_world.apworld"
+
+[versions]
+"1.0.0" = {}


### PR DESCRIPTION
This is a new Archipelago mod for Celeste that makes it more in the vein of a traditional randomizer, having interactions with some interactable objects locked behind checks and locations. It's highly customizable and very fun to play!