### PR TITLE
Add anodyne 0.2.4

### DIFF
--- a/index/anodyne.toml
+++ b/index/anodyne.toml
@@ -6,3 +6,4 @@ default_url = "https://github.com/PixieCatSupreme/ArchipelagoAno/releases/downlo
 "0.1.7" = {}
 "0.1.9" = {}
 "0.2.3" = {}
+"0.2.4" = {}


### PR DESCRIPTION
Fixes quite a few logic errors relating to dustsanity locations being in logic when they shouldn't be. See changelog on the apworld github for more details.