### PR TITLE
Update Sonic Adventure DX

### DIFF
--- a/index/sadx.toml
+++ b/index/sadx.toml
@@ -8,3 +8,4 @@ default_url = "https://github.com/ClassicSpeed/sadx-classic-randomizer/releases/
 "1.0.0" = {}
 "1.0.1" = {}
 "1.1.0" = {}
+"1.1.1-b" = { url = "https://github.com/ClassicSpeed/sadx-classic-randomizer/releases/download/v1.1.1b/sadx.apworld" }


### PR DESCRIPTION
Skipped 1.1.1, going straight to the corrective 1.1.1-b release (should just be fixes on the mod side).