### PR TITLE
Add manual for Lego Star Wars: The Complete Saga

### DIFF
--- a/index/manual_legostarwarsthecompletesaga_mysteryem.toml
+++ b/index/manual_legostarwarsthecompletesaga_mysteryem.toml
@@ -1,0 +1,8 @@
+name = "Manual_LegoStarWarsTheCompleteSaga_mysteryem"
+display_name = "Manual: Lego Star Wars The Complete Saga"
+home = "https://discord.com/channels/1097532591650910289/1156373916370083880"
+default_url = "https://github.com/Mysteryem/ManualForArchipelago/releases/download/lsw_tcs_{{version}}/manual_legostarwarsthecompletesaga_mysteryem.apworld"
+
+[versions]
+# Manual version: https://github.com/Mysteryem/ManualForArchipelago/releases/tag/python_logic_functions_v0.0.1
+"0.7.1" = {}

--- a/index/manual_legostarwarsthecompletesaga_mysteryem.toml
+++ b/index/manual_legostarwarsthecompletesaga_mysteryem.toml
@@ -1,4 +1,4 @@
-name = "Manual_LegoStarWarsTheCompleteSaga_mysteryem"
+name = "Manual_LegoStarWarsTheCompleteSaga_Mysteryem"
 display_name = "Manual: Lego Star Wars The Complete Saga"
 home = "https://discord.com/channels/1097532591650910289/1156373916370083880"
 default_url = "https://github.com/Mysteryem/ManualForArchipelago/releases/download/lsw_tcs_{{version}}/manual_legostarwarsthecompletesaga_mysteryem.apworld"

--- a/index/manual_legostarwarsthecompletesaga_mysteryem.toml
+++ b/index/manual_legostarwarsthecompletesaga_mysteryem.toml
@@ -4,5 +4,5 @@ home = "https://discord.com/channels/1097532591650910289/1156373916370083880"
 default_url = "https://github.com/Mysteryem/ManualForArchipelago/releases/download/lsw_tcs_{{version}}/manual_legostarwarsthecompletesaga_mysteryem.apworld"
 
 [versions]
-# Manual version: https://github.com/Mysteryem/ManualForArchipelago/releases/tag/python_logic_functions_v0.0.1
-"0.7.1" = {}
+# Manual version: https://github.com/Mysteryem/ManualForArchipelago/releases/tag/python_logic_functions_v0.0.2
+"0.8.0" = {}


### PR DESCRIPTION
This is a repack of Roush's v7.1 Lego Star Wars: The Complete Saga manual world:
https://discord.com/channels/1097532591650910289/1156373916370083880/1290558889963552789

The repack uses my work-in-progress fork of manual that improves logic performance. Because this fork is based on neither a stable nor unstable release of manual, the included manual client is given the lowest possible priority, causing manual clients from other loaded manual worlds to be loaded in preference to the client included in this world.

---

I think it could be worth giving the version an extra identifier rather than just `0.7.1` to help indicate that this uses a potentially unstable version of manual (more so than the official 'unstable' releases), I've seen `-alpha+unreleased` used for Celeste for example.