### PR TITLE
Add ALBW (A Link Between World)

### DIFF
--- a/index/albw.toml
+++ b/index/albw.toml
@@ -1,0 +1,6 @@
+name = "A Link Between Worlds"
+home = "https://discord.com/channels/731205301247803413/1183624197935730758"
+default_url = "https://github.com/randomsalience/albw-archipelago/releases/download/v{{version}}/albw.apworld"
+
+[versions]
+"0.1.2" = {}


### PR DESCRIPTION
This adds the albw apworld
I have a problem being that it also needs a lib based on the standalone randomizer that might change every version, the lib is in the same release but under the name "albwrandomizer.zip" compared to the apworld "albw.apworld".
For local use the lib just get extracted from the .zip and pasted in the lib folder of AP.
Generating does not need internet but needs the lib to be accessible (and will generate a patch)