### PR TITLE
Update crosscode.toml to 0.6.8

### DIFF
--- a/index/crosscode.toml
+++ b/index/crosscode.toml
@@ -7,3 +7,4 @@ default_url = "https://github.com/CodeTriangle/CCMultiworldRandomizer/releases/d
 "0.6.4" = {}
 "0.6.5" = {}
 "0.6.6" = {}
+"0.6.8" = {}


### PR DESCRIPTION
Skipping 0.6.7 as a newer version has released since.