### PR TITLE
Update Sims 4 APWorld to 1.6.0

### DIFF
--- a/index/sims4.toml
+++ b/index/sims4.toml
@@ -7,3 +7,4 @@ default_url = "https://github.com/benny-dreamly/Archipelago/releases/download/si
 "1.5.0" = {url = "https://github.com/meaomeaomeaoo/Archipelago/releases/download/1.5/sims4.apworld"}
 "1.5.1" = {}
 "1.5.2" = {}
+"1.6.0" = {}


### PR DESCRIPTION
I've just released the new sims 4 apworld, now that I had some time to make the 1.6.0 world not a pre-release, so now that I've done that, I'm PRing the update here. The changes shouldn't be too big... we hope!