### PR TITLE
Update ape_escape_3.toml to 1.0.71

### DIFF
--- a/index/ape_escape_3.toml
+++ b/index/ape_escape_3.toml
@@ -5,3 +5,4 @@ default_url = "https://github.com/aidanii24/ae3-archipelago/releases/download/v{
 [versions]
 "1.0.60" = {}
 "1.0.70" = {}
+"1.0.71" = {}


### PR DESCRIPTION
Someone mentioned updating in the Chrism server, and this just dropped. Hate to update so quickly after.