### PR TITLE
Update "Home" links for games that moved from thread to designated channel in main AP discord

### DIFF
--- a/index/Twilight Princess.toml
+++ b/index/Twilight Princess.toml
@@ -1,5 +1,5 @@
 name = "Twilight Princess"
-home = "https://discord.com/channels/731205301247803413/1110253490875404388"
+home = "https://discord.com/channels/731205301247803413/1369050080887312506"
 
 [versions]
 "0.2.3" = { local = "../apworlds/Twilight Princess-0.2.3.apworld" }

--- a/index/celeste.toml
+++ b/index/celeste.toml
@@ -1,5 +1,5 @@
 name = "Celeste"
-home = "https://discord.com/channels/731205301247803413/1021069526625947729"
+home = "https://discord.com/channels/731205301247803413/1367624611256205443"
 default_url = "https://github.com/doshyw/CelesteArchipelago/releases/download/{{version}}/celeste.apworld"
 
 [versions]

--- a/index/dsr.toml
+++ b/index/dsr.toml
@@ -1,5 +1,5 @@
 name = "Dark Souls Remastered"
-home = "https://discord.com/channels/731205301247803413/1092600948548976680"
+home = "https://discord.com/channels/731205301247803413/1367143578576621670"
 default_url = "https://github.com/ArsonAssassin/DSAP/releases/download/{{version}}/dsr.apworld"
 
 [versions]

--- a/index/papermario.toml
+++ b/index/papermario.toml
@@ -1,5 +1,5 @@
 name = "Paper Mario"
-home = "https://discord.com/channels/731205301247803413/1059875783071502398"
+home = "https://discord.com/channels/731205301247803413/1369329691076329582"
 default_url = "https://github.com/JKBSunshine/PMR_APWorld/releases/download/v{{version}}/papermario.apworld"
 
 [versions]

--- a/index/pokemon_frlg.toml
+++ b/index/pokemon_frlg.toml
@@ -1,5 +1,5 @@
 name = "Pokemon FireRed and LeafGreen"
-home = "https://discord.com/channels/731205301247803413/1232325933902467082"
+home = "https://discord.com/channels/731205301247803413/1365127226533871718"
 default_url = "https://github.com/vyneras/Archipelago/releases/download/{{version}}/pokemon_frlg.apworld"
 
 [versions]


### PR DESCRIPTION
Twilight Princess, Celeste, Dark souls 1, paper mario 64 and pokemon FireRed/LeafGreen