### PR TITLE
Replace pokemon_crystal 4.0.4 with 4.0.5

### DIFF
--- a/index/pokemon_crystal.toml
+++ b/index/pokemon_crystal.toml
@@ -18,4 +18,4 @@ default_url = "https://github.com/gerbiljames/Archipelago/releases/download/{{ve
 "4.0.1" = {}
 "4.0.2" = {}
 "4.0.3" = {}
-"4.0.4" = {}
+"4.0.5" = {}


### PR DESCRIPTION
Removing 4.0.4 since it shouldn't be used