### PR TITLE
Update 0.8.9 for Ape Escape

### DIFF
--- a/index/apeescape.toml
+++ b/index/apeescape.toml
@@ -6,3 +6,4 @@ default_url = "https://github.com/Thedragon005/Archipelago-Ape-Escape/releases/d
 "0.8.5" = {}
 "0.8.7" = {}
 "0.8.8" = {}
+"0.8.9" = {}


### PR DESCRIPTION
Players that reports "Coins" are not sending that are currently on a 0.8.8 seed can download this patch and replace their apworld