### PR TITLE
Update mm3.toml

### DIFF
--- a/index/mm3.toml
+++ b/index/mm3.toml
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1250369456048177152"
 default_url = "https://github.com/Silvris/Archipelago/releases/download/mm3_{{version}}/mm3.apworld"
 
 [versions]
-"0.1.1" = {}
+"0.1.3" = {}


### PR DESCRIPTION
0.1.1 is nonfunctional on AP 0.6.2.