### PR TITLE
Disable balatro

### DIFF
--- a/index/balatro.toml
+++ b/index/balatro.toml
@@ -1,5 +1,6 @@
 name = "Balatro"
 home = "https://discord.com/channels/731205301247803413/1220179325739864168"
+disabled = true
 
 [versions]
 "0.1.9-b" = { url = "https://github.com/BurndiL/BalatroAP/releases/download/v0.1.9b/balatro.apworld" }


### PR DESCRIPTION
This has been a long time coming, it got in before we got stricter with inclusion and has been a pain for a while. Right now it's failing at *least* 40% of my gen attempts so goodbye, come back when you're fixed.