### PR TITLE
OpenRCT2 Default URL change - again

### DIFF
--- a/index/openrct2.toml
+++ b/index/openrct2.toml
@@ -3,9 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1095746758774108240"
 default_url =  "https://github.com/Crazycolbster/rollercoaster-tycoon-randomizer/releases/download/v{{version}}/openrct2.apworld"
 
 [versions]
-"0.1.13-beta" = {}
-"0.1.15-beta" = {}
-"0.1.16-beta" = {}
-"0.1.17-beta" = {}
-"0.1.18-beta" = {}
 "0.1.19-beta" = {}

--- a/index/openrct2.toml
+++ b/index/openrct2.toml
@@ -1,11 +1,11 @@
 name = "OpenRCT2"
 home = "https://discord.com/channels/731205301247803413/1095746758774108240"
-default_url =  "https://github.com/Crazycolbster/rollercoaster-tycoon-randomizer/releases/download/v.{{version}}/openrct2.apworld"
+default_url =  "https://github.com/Crazycolbster/rollercoaster-tycoon-randomizer/releases/download/v{{version}}/openrct2.apworld"
 
 [versions]
-"0.1.13-beta" = { url = "https://github.com/Crazycolbster/rollercoaster-tycoon-randomizer/releases/download/0.1.13-beta/openrct2.apworld" }
-"0.1.15-beta" = { url = "https://github.com/Crazycolbster/rollercoaster-tycoon-randomizer/releases/download/v0.1.15-beta/openrct2.apworld" }
-"0.1.16-beta" = { url = "https://github.com/Crazycolbster/rollercoaster-tycoon-randomizer/releases/download/v0.1.16-beta/openrct2.apworld" }
+"0.1.13-beta" = {}
+"0.1.15-beta" = {}
+"0.1.16-beta" = {}
 "0.1.17-beta" = {}
 "0.1.18-beta" = {}
 "0.1.19-beta" = {}


### PR DESCRIPTION
The dev changed the default url for the tags as requested by AP contributors from "v.0.x.yy" to "v0.x.yy".

Confirmed that the default url "v{{version}}" worked for all releases in the index by editing the url for the numbered release.