### PR TITLE
Add Haste

### DIFF
--- a/index/haste.toml
+++ b/index/haste.toml
@@ -1,0 +1,6 @@
+name = "Haste"
+home = "https://discord.com/channels/731205301247803413/1356638437872111687"
+default_url = "https://github.com/WritingHusky/haste_apworld/releases/download/v{{version}}/haste.apworld"
+
+[versions]
+"0.3.2" = {}


### PR DESCRIPTION
~~`default_url` does not point to an actual file. The GH Release is a zip containing the apworld, YAML, license, and README.~~

Fuzzing and general apworld usage *may* fail with `Menu already exists in region cache.`
Encountered with `Archipelago (0.6.3), Python 3.12.10` (source)
Not encountered witth `Archipelago (0.6.3), Python 3.12.10 (frozen)` (a typical install)
