### PR TITLE
Update The Sims 4 to 1.6.1

### DIFF
--- a/index/sims4.toml
+++ b/index/sims4.toml
@@ -1,10 +1,7 @@
 name = "The Sims 4"
 home = "https://discord.com/channels/731205301247803413/1079002955262480424"
-default_url = "https://github.com/benny-dreamly/Archipelago/releases/download/sims-{{version}}/sims4.apworld"
+default_url = "https://github.com/Simsipelago/Archipelago/releases/download/{{version}}/sims4.apworld"
 
 [versions]
 
-"1.5.0" = {url = "https://github.com/meaomeaomeaoo/Archipelago/releases/download/1.5/sims4.apworld"}
-"1.5.1" = {}
-"1.5.2" = {}
-"1.6.0" = {}
+"1.6.1" = {}


### PR DESCRIPTION
This PR updates the Sims APWorld to 1.6.1, and removed the links to the older versions, and repoints the default_url to the new repository.