### PR TITLE
Disable/Remove Candy Box 2

### DIFF
--- a/index/candybox2.toml
+++ b/index/candybox2.toml
@@ -1,5 +1,7 @@
 name = "Candy Box 2"
 home = "https://discord.com/channels/731205301247803413/1351112920398037015/"
+# this version of candy box 2 is really outdated and causes issues for a lot of people, so disabling it is the best course of action
+disabled = true
 
 [versions]
 "0.1.0+20250409-1" = { url = "https://github.com/vicr123/Archipelago/releases/download/20250409-1/candybox2.apworld" }


### PR DESCRIPTION
The version in the index is so old compared to current that it's super inconvenient to deal with submissions for modern versions of the apworld, and since my update PR seems to be getting nowhere fast, this seems like the best course of action. 