### PR TITLE
Update MM3

### DIFF
--- a/index/mm3.toml
+++ b/index/mm3.toml
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1250369456048177152"
 default_url = "https://github.com/Silvris/Archipelago/releases/download/mm3_{{version}}/mm3.apworld"
 
 [versions]
-"0.1.3" = {}
+"0.1.4" = {}


### PR DESCRIPTION
Getting ahead of the curve here, MM3 0.1.3 breaks on AP 0.6.4, so 0.1.4 is now compatible with both.