### PR TITLE
Remove guitar hero 3 manual

### DIFF
--- a/index/manual_guitarhero3_garbo.toml
+++ b/index/manual_guitarhero3_garbo.toml
@@ -1,6 +1,0 @@
-name = "Manual_guitarhero3_garbo"
-display_name = "Manual: Guitar Hero 3"
-home = "https://discord.com/channels/1097532591650910289/1174450775888494642"
-
-[versions]
-"1.3.0" = { url = "https://github.com/ManNamedGarbo/GH3_APManual/releases/download/release13/manual_guitarhero3_garbo.apworld" }


### PR DESCRIPTION
It had been discontinued and the repo is now gone...