### PR TITLE
Jigsaw: update to 0.9.1 (small bugfix)

### DIFF
--- a/index/jigsaw.toml
+++ b/index/jigsaw.toml
@@ -8,3 +8,4 @@ default_url = "https://github.com/spineraks-org/ArchipelagoJigsaw/releases/downl
 "0.7.2" = {}
 "0.8.0" = {}
 "0.9.0" = {}
+"0.9.1" = {}


### PR DESCRIPTION
This version is just a bugfix and you can use the same yaml as for 0.9.0!!!!! chrisWow