### PR TITLE
Reenable Simpsons Hit And Run, Update to 0.4.3-b

### DIFF
--- a/index/simpsonshitnrun.toml
+++ b/index/simpsonshitnrun.toml
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1158211913495359548"
 default_url = "https://github.com/nmize1/Archipelago/releases/download/v{{version}}/simpsonshitnrun.apworld"
 
 [versions]
-"0.3.7-b" = {}
+"0.3.10-b" = {}

--- a/index/simpsonshitnrun.toml
+++ b/index/simpsonshitnrun.toml
@@ -1,6 +1,7 @@
 name = "The Simpsons Hit And Run"
 home = "https://discord.com/channels/731205301247803413/1158211913495359548"
-disabled = true # Old versions are gone, new versions don't pass fuzzing.
+default_url = "https://github.com/nmize1/Archipelago/releases/download/v{{version}}/simpsonshitnrun.apworld"
 
 [versions]
 "0.1.6-alpha" = { url = "https://github.com/nmize1/Archipelago/releases/download/v0.1.6a/simpsonshitnrun.apworld" }
+"0.3.6b" = {}

--- a/index/simpsonshitnrun.toml
+++ b/index/simpsonshitnrun.toml
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1158211913495359548"
 default_url = "https://github.com/nmize1/Archipelago/releases/download/v{{version}}/simpsonshitnrun.apworld"
 
 [versions]
-"0.3.10-b" = {}
+"0.4.3-b" = {}

--- a/index/simpsonshitnrun.toml
+++ b/index/simpsonshitnrun.toml
@@ -3,5 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1158211913495359548"
 default_url = "https://github.com/nmize1/Archipelago/releases/download/v{{version}}/simpsonshitnrun.apworld"
 
 [versions]
-"0.1.6-alpha" = { url = "https://github.com/nmize1/Archipelago/releases/download/v0.1.6a/simpsonshitnrun.apworld" }
-"0.3.6b" = {}
+"0.3.6-b" = { url = "https://github.com/nmize1/Archipelago/releases/download/v0.3.6b/simpsonshitnrun.apworld" }

--- a/index/simpsonshitnrun.toml
+++ b/index/simpsonshitnrun.toml
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1158211913495359548"
 default_url = "https://github.com/nmize1/Archipelago/releases/download/v{{version}}/simpsonshitnrun.apworld"
 
 [versions]
-"0.3.6-b" = { url = "https://github.com/nmize1/Archipelago/releases/download/v0.3.6b/simpsonshitnrun.apworld" }
+"0.3.7-b" = {}


### PR DESCRIPTION
Reenable Simpsons Hit And Run, Update to 0.3.6b