### PR TITLE
Add Sly 2 (ChrisM Event Ver)

### DIFF
--- a/index/sly2.toml
+++ b/index/sly2.toml
@@ -6,5 +6,5 @@ default_url = "https://github.com/Awsomeman328/APSly2/releases/download/v{{versi
 # the regular public release builds (currently) have a failure rate of about 80% with the fuzzer tool and shouldn't be used until fixed.
 
 [versions]
-"0.1.3-chrism" = {}
+"0.1.3-chrism" = { }
 


### PR DESCRIPTION
This will attempt to use a specific & special build version of this APWorld that guarantees that more locations than items will be generated for itself. Don't use the regular release version from the official repo until this has been officially addressed there.