### PR TITLE
Downgrade Sims 4 APWorld to properly stable release

### DIFF
--- a/index/sims4.toml
+++ b/index/sims4.toml
@@ -1,9 +1,7 @@
 name = "The Sims 4"
 home = "https://discord.com/channels/731205301247803413/1079002955262480424"
 default_url = "https://github.com/Simsipelago/Archipelago/releases/download/{{version}}/sims4.apworld"
-disabled = true
 
 [versions]
 
 "1.6.1" = {}
-"2.0.0-beta.1" = {}


### PR DESCRIPTION
#1009 updated the APWorld to a version that is **not considered stable enough** to use in public syncs or asyncs without prior knowledge from the host. There are several large client issues that are still in need of fixing, along with multiple other things that are probably unknown at this point. 

This is currently the best course of action until I have time to finish the beta.

A future PR will add the properly stable version of the APWorld that is recommended for public use. 