### PR TITLE
Add Manual: Buckshot Roulette

### DIFF
--- a/index/manual_cars_wolfboi008.toml
+++ b/index/manual_cars_wolfboi008.toml
@@ -1,7 +1,0 @@
-name = "Manual_Cars_WolfBoi008"
-display_name = "Manual: Cars"
-home = "https://github.com/WolfBoi008/Cars/tree/main"
-default_url = "https://github.com/WolfBoi008/Cars/releases/download/{{version}}/manual_cars_wolfboi008.apworld"
-
-[versions]
-"1.2.1" = {}


### PR DESCRIPTION
I saw that the Buckshot Roulette one failed before when someone else wanted to play it. I believe the issue has now been isolated, and this version should patch it up so it can be added to the index. I'm also adding some of my other Manuals so they can be put on the index.