### PR TITLE
Update Manual: Block Tales

### DIFF
--- a/index/manual_blocktales_wolfboi008.toml
+++ b/index/manual_blocktales_wolfboi008.toml
@@ -1,7 +1,7 @@
 name = "Manual_BlockTales_WolfBoi008"
 display_name = "Manual: Block Tales"
-home = "https://discord.com/channels/1097532591650910289/1377245145493274644"
+home = "https://github.com/WolfBoi008/Block-Tales"
 default_url = "https://github.com/WolfBoi008/Block-Tales/releases/download/{{version}}/manual_blocktales_wolfboi008.apworld"
 
 [versions]
-"4.0.2" = {}
+"4.1.0" = {}


### PR DESCRIPTION
Update Block Tales Manual to 4.1.0. Also updates its home link to be the GitHub page.