### PR TITLE
Update APworld version of Crystal Project to 0.11.2

### DIFF
--- a/index/crystal_project.toml
+++ b/index/crystal_project.toml
@@ -5,4 +5,4 @@ default_url = "https://github.com/Emerassi/CrystalProjectAPWorld/releases/downlo
 [versions]
 "0.7.0" = {}
 "0.9.0" = {}
-"0.11.2" = {}
+"0.11.4" = {}


### PR DESCRIPTION
I see there is another PR of Crystal Project from 0.9 to 0.10.

0.11.2 has a lot of bugfixes, and a big chunck of logic revamp.
Hope it passes the fuzzer !