### PR TITLE
Update hitman_woa.toml to 0.6.2

### DIFF
--- a/index/hitman_woa.toml
+++ b/index/hitman_woa.toml
@@ -5,4 +5,5 @@ default_url = "https://github.com/BenDipp/Archipelago/releases/download/{{versio
 
 [versions]
 "0.5.1" = {}
+"0.6.0" = {}
 "0.6.2" = {}


### PR DESCRIPTION
0.6.2 passes the fuzzer with a failure rate of << 1% on my machine. 0.6.2 fixes some bugs with 0.6.0, including bugs with the yaml being considered invalid when it should not be and client-side crashing. I had previously opened a PR with this change, but I closed it because I thought a new version of the APWorld was coming soon which does not appear to be the case. Not super high priority.