### PR TITLE
Update Sims 4 to 1.7.5

### DIFF
--- a/index/sims4.toml
+++ b/index/sims4.toml
@@ -5,3 +5,4 @@ default_url = "https://github.com/Simsipelago/Archipelago/releases/download/{{ve
 [versions]
 
 "1.6.1" = {}
+"1.7.5" = {}


### PR DESCRIPTION
This is a new APWorld that doesn't change any of the generation parts of the world, only the client. 

(this update is only being PRed now, because I just released a newer one to encourage people to update, and I finally fixed some mod side issues that were being annoying)