### PR TITLE
Ape Escape hotfix 0.9.4

### DIFF
--- a/index/apeescape.toml
+++ b/index/apeescape.toml
@@ -3,7 +3,7 @@ home = "https://discord.com/channels/731205301247803413/1168645708103028856"
 default_url = "https://github.com/Thedragon005/Archipelago-Ape-Escape/releases/download/v{{version}}/apeescape.apworld"
 
 [versions]
-"0.9.0-a" = {url = "https://github.com/Thedragon005/Archipelago-Ape-Escape/releases/download/v0.9.0a/apeescape.apworld"}
 "0.9.1" = {}
 "0.9.2" = {}
 "0.9.3" = {}
+"0.9.4" = {}


### PR DESCRIPTION
0.9.3 seeds can be used with this update, this is an hotfix for it