### PR TITLE
Update Nine Sols to v0.4.3

### DIFF
--- a/index/nine_sols.toml
+++ b/index/nine_sols.toml
@@ -8,3 +8,4 @@ default_url = "https://github.com/Ixrec/NineSolsArchipelagoRandomizer/releases/d
 "0.1.6" = {}
 "0.2.1" = {}
 "0.3.6" = {}
+"0.4.3" = {}


### PR DESCRIPTION
Updating Nine Sols toml to include latest apworld version.

Main improvements are addition of shop unlock logic, trick logic, and the ability to disable weakened mode in prison escape sequence (with associated logic).