### PR TITLE
SoH to OoT: SoH

### DIFF
--- a/index/oot_soh.toml
+++ b/index/oot_soh.toml
@@ -1,6 +1,7 @@
 name = "Ship of Harkinian"
 home = "https://discord.com/channels/731205301247803413/1434235335625281707"
 default_url = "https://github.com/HarbourMasters/Archipelago-SoH/releases/download/SoH_{{version}}/oot_soh.apworld"
+display_name = "Ocarina of Time: Ship of Harkinian"
 
 [versions]
 "1.0.0" = {}


### PR DESCRIPTION
Just a simple change to avoid confusion when it comes to Ship, making it clear that it is an Ocarina of Time port.