### PR TITLE
Update Block Tales Manual to 4.1.2

### DIFF
--- a/index/manual_blocktales_wolfboi008.toml
+++ b/index/manual_blocktales_wolfboi008.toml
@@ -4,5 +4,4 @@ home = "https://discord.com/channels/1097532591650910289/1377245145493274644"
 default_url = "https://github.com/WolfBoi008/Block-Tales/releases/download/{{version}}/manual_blocktales_wolfboi008.apworld"
 
 [versions]
-"4.0.2" = {}
-"4.1.1" = {}
+"4.1.2" = {}


### PR DESCRIPTION
Update the Block Tales Manual from Version 4.1.1 to Version 4.1.2.