### PR TITLE
Update display name and version for One More Night Manual

### DIFF
--- a/index/manual_onemorenight_wolfboi008.toml
+++ b/index/manual_onemorenight_wolfboi008.toml
@@ -1,7 +1,7 @@
 name = "Manual_OneMoreNight_WolfBoi008"
-display_name = "Manual: One More Night"
+display_name = "Manual: One More Night (Roblox)"
 home = "https://github.com/WolfBoi008/One-More-Night"
 default_url = "https://github.com/WolfBoi008/One-More-Night/releases/download/{{version}}/manual_onemorenight_wolfboi008.apworld"
 
 [versions]
-"2.2.0" = {}
+"2.2.1" = {}


### PR DESCRIPTION
Update the One More Night Manual to 2.2.1 and specify in its display name that it's a game on Roblox (since apparently more than one game with the name One More Night exists).