### PR TITLE
Replace SoH 1.1.0 with the hotfix

### DIFF
--- a/index/oot_soh.toml
+++ b/index/oot_soh.toml
@@ -5,4 +5,4 @@ display_name = "Ocarina of Time: Ship of Harkinian"
 
 [versions]
 "1.0.0" = {}
-"1.1.0" = {}
+"1.1.0+hotfix" = { url = "https://github.com/HarbourMasters/Archipelago-SoH/releases/download/SoH_1.1.0-Hotfix/oot_soh.apworld" }


### PR DESCRIPTION
Hotfix fixes gen with games using GER. Don't see a point in keeping 1.1.0.