### PR TITLE
Add Wargroove 2

### DIFF
--- a/index/wargroove2.toml
+++ b/index/wargroove2.toml
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1159482310652076082"
 default_url = "https://github.com/FlySniper/Archipelago/releases/download/wargroove2-{{version}}/wargroove2.apworld"
 
 [versions]
-"1.1.4" = {}
+"1.1.5" = {}


### PR DESCRIPTION
Wargroove 2 features a completely custom campaign with custom levels. As such, there's options to remove levels players don't like from the campaign. This can cause generation errors since there won't be enough locations to fill in all the required items. The amount of required levels is dynamic depending on other options which are set. With the right settings, Wargroove 2 can generate a game with, let's say 10+ levels. With other settings, 15+ levels might be required for a successful generation.