### PR TITLE
Split l1/l3 task caches

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -13,7 +13,6 @@ policy:
 tasks:
     - $let:
           trustDomain: "ap"
-          level: "1"
           ownerEmail:
               $switch:
                   'tasks_for == "github-push"': '${event.pusher.email}'
@@ -106,6 +105,11 @@ tasks:
                       'head_ref[:10] == "refs/tags/"': '${head_ref[10:]}'
                       'head_ref[:11] == "refs/heads/"': '${head_ref[11:]}'
                       $default: '${head_ref}'
+              level:
+                  $switch:
+                      'tasks_for in ["action", "pr-action", "cron", "github-issue-comment"]': "3"
+                      'tasks_for == "github-push" && head_ref == "refs/heads/main"': "3"
+                      $default: "1"
           in:
               $if: >
                   tasks_for in ["action", "pr-action", "cron", "github-issue-comment"]


### PR DESCRIPTION
This will prevent caches from being shared between trusted and untrusted tasks