### PR TITLE
Update Cat Quest to 0.3.0-alpha

### DIFF
--- a/index/cat_quest.toml
+++ b/index/cat_quest.toml
@@ -4,3 +4,4 @@ default_url = "https://github.com/Nikkilites/Archipelago-CatQuest/releases/downl
 
 [versions]
 "0.2.3-alpha" = {}
+"0.3.0-alpha" = {}


### PR DESCRIPTION
I fuzzed 10k and got 6 fails (Fill.FillError: Could not access required locations for accessibility check). Following up with the dev on that myself.