### PR TITLE
Update Plants vs. Zombies Replanted to 1.4.1

### DIFF
--- a/index/pvzr.toml
+++ b/index/pvzr.toml
@@ -7,3 +7,4 @@ default_url = "https://github.com/dannybonz/replanted_archipelago/releases/downl
 "1.3.1" = {}
 "1.3.3" = {}
 "1.4.0" = {}
+"1.4.1" = {}


### PR DESCRIPTION
Has some bugfixes compared to 1.4.0 most notably this one that could result in seeds that breaks the client:
> Fixes a bug where Seed Stat Randomisation could create values so high that it would crash the game.

Full patch notes can be found on the github page 