### PR TITLE
Update Lies of P to 0.1.5

### DIFF
--- a/index/liesofp.toml
+++ b/index/liesofp.toml
@@ -5,3 +5,4 @@ default_url = "https://github.com/Xtruh/LiesOfAP/releases/download/{{version}}/l
 [versions]
 "0.1.3" = {}
 "0.1.4" = {}
+"0.1.5" = {}


### PR DESCRIPTION
Excellent fuzzing results and you will be pleased to know that this is in the patch notes:
- Added a item queue to reduce constant crashing from large releases
