### PR TITLE
Update Nine Sols to 0.4.4

### DIFF
--- a/index/nine_sols.toml
+++ b/index/nine_sols.toml
@@ -9,3 +9,4 @@ default_url = "https://github.com/Ixrec/NineSolsArchipelagoRandomizer/releases/d
 "0.2.1" = {}
 "0.3.6" = {}
 "0.4.3" = {}
+"0.4.4" = {}


### PR DESCRIPTION
- Major logic fixes
- Fix jade cost randomization for non-English languages
- Fix crashing on close
- Apworld version difference warning