### PR TITLE
Update Final Fantasy IV: Free Enterprise to Version 7

### DIFF
--- a/index/ff4fe.toml
+++ b/index/ff4fe.toml
@@ -1,6 +1,5 @@
 name = "Final Fantasy IV Free Enterprise"
 home = "https://discord.com/channels/731205301247803413/1170144930610557008"
-disabled = true # 25% failure rate on 0.6.0
 
 [versions]
-"0.6.0" = {}
+"7.0.0" = {url="https://github.com/Rosalie-A/Archipelago/releases/download/FFIV-AP-v7/ff4fe.apworld"}


### PR DESCRIPTION
Was disabled due to 25% fuzz failures. Version 7 makes it 0.9% fuzz failure.