### PR TITLE
Re-enabled wordipelago with lower failure rate version

### DIFF
--- a/index/wordipelago.toml
+++ b/index/wordipelago.toml
@@ -1,10 +1,6 @@
 name = "Wordipelago"
 home = "https://discord.com/channels/731205301247803413/1336387000928047186"
 default_url = "https://github.com/ProfDeCube/Archipelago/releases/download/{{version}}/wordipelago.apworld"
-disabled = true # 1.6% failure rate
 
 [versions]
-"0.8.4" = {}
-"0.8.5" = {}
-"0.8.6" = {}
-"1.0.0" = {}
+"1.0.2" = {}


### PR DESCRIPTION
removed all old versions, now only the new version with the much lower failure rate is present