### PR TITLE
Update pokepelago to 0.5.1

### DIFF
--- a/index/pokepelago.toml
+++ b/index/pokepelago.toml
@@ -4,3 +4,4 @@ default_url = "https://github.com/dowlle/PokepelagoClient/releases/download/v{{v
 
 [versions]
 "0.4.4" = {}
+"0.5.1" = {}


### PR DESCRIPTION
Adds version 0.5.1 for Pokepelago.

Changes in this release:
- Fixed incorrect trade evolution data (Foongus/Accelgor ID swap, missing Trevenant/Gourgeist)
- New YAML option: `master_ball_bypass_gates` - lets players choose whether Master Balls ignore lock gates
- Guided tour for new players
- Multiple client bugfixes (non-English guessing, trap re-fire, stone gate desync)
- Packaging fix: test files no longer included in .apworld

Full release notes: https://github.com/dowlle/PokepelagoClient/releases/tag/v0.5.1

Local fuzzer: 10/10 passed, 0 failures, 14,000 runs.