### PR TITLE
Add We Love Katamari Reroll

### DIFF
--- a/index/wlkrr.toml
+++ b/index/wlkrr.toml
@@ -1,0 +1,7 @@
+name = "We Love Katamari Reroll"
+home = "https://discord.com/channels/731205301247803413/1141745266723131523"
+default_url = "https://github.com/sapphisylph/We-Love-Archipelago-Reroll/releases/download/v{{version}}/wlkrr.apworld"
+
+[versions]
+
+"0.1.0" = {}


### PR DESCRIPTION
just released the official apworld today, here's the finished product

this was made using the fuzzer as a debug tool, so this should have no problems fuzzing (unless something went terribly wrong), but im curious how it will do on the other tests.

on top of this though, i am also the author of the we love katamari manual thats hosted on bananium as well, so ill leave it up to you whether or not you want to remove the manual from the index as well if this does get through. this apworld achieves mostly the same things as the manual had, so it won't be losing much if you do.