### PR TITLE
Added crabchampions.toml

### DIFF
--- a/index/crabchampions.toml
+++ b/index/crabchampions.toml
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1295008123131658270"
 default_url = "https://github.com/Str8UpWHITE64/CrabChampionsAP/releases/download/{{version}}/crabchampions.apworld"
 
 [versions]
-"1.2.0" = {}
+"1.3.0" = {}

--- a/index/crabchampions.toml
+++ b/index/crabchampions.toml
@@ -1,6 +1,6 @@
 name = "Crab Champions"
 home = "https://discord.com/channels/731205301247803413/1295008123131658270"
 default_url = "https://github.com/Str8UpWHITE64/CrabChampionsAP/releases/download/{{version}}/crabchampions.apworld"
+
 [versions]
-"1.1.2" = {}
 "1.2.0" = {}

--- a/index/crabchampions.toml
+++ b/index/crabchampions.toml
@@ -1,0 +1,5 @@
+name = "Crab Champions"
+home = "https://discord.com/channels/731205301247803413/1295008123131658270"
+default_url = "https://github.com/Str8UpWHITE64/CrabChampionsAP/releases/download/{{version}}/crabchampions.apworld"
+[versions]
+"1.1.2" = {}

--- a/index/crabchampions.toml
+++ b/index/crabchampions.toml
@@ -3,3 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1295008123131658270"
 default_url = "https://github.com/Str8UpWHITE64/CrabChampionsAP/releases/download/{{version}}/crabchampions.apworld"
 [versions]
 "1.1.2" = {}
+"1.2.0" = {}


### PR DESCRIPTION
Initial version for crabcrampions 1.1.2
and update for 1.2.0

Suggestions to block bloated slots
```
# If on generates for each new pickup 1 check. Similar to dexsanity but worse since some upgrades can only be found if you received a different upgrade before.
pickup_checks: false
# When enabled, island completions and equipment runs are tracked per rank for ALL ranks up to Max Rank, not just the Required Rank.
# So depending on the run length minumum of 28 checks per weapon per rank configured.
extra_ranked_island_checks: false
# Can be turned on but still leads to alot of checks in the pool and a huge sphere 1 since they are all available
equipment_check_mode: disabled
```