### PR TITLE
Add Yellow Taxi Goes Vroom

### DIFF
--- a/index/yellowtaxi.txt
+++ b/index/yellowtaxi.txt
@@ -3,4 +3,4 @@ home = "https://discord.com/channels/731205301247803413/1265482079118950422"
 default_url = "https://github.com/soopercool101/Archipelago/releases/download/YTGV.v{{version}}/yellowtaxi.apworld"
 
 [versions]
-"0.3.1" = {}
+"0.3.2" = {}

--- a/index/yellowtaxi.txt
+++ b/index/yellowtaxi.txt
@@ -1,0 +1,6 @@
+name = "Yellow Taxi Goes Vroom"
+home = "https://discord.com/channels/731205301247803413/1265482079118950422"
+default_url = "https://github.com/soopercool101/Archipelago/releases/download/YTGV.v{{version}}/yellowtaxi.apworld"
+
+[versions]
+"0.3.1" = {}


### PR DESCRIPTION
Adds Yellow Taxi Goes Vroom to the index. Note that this world has a lot of possible locations from its `coinsanity` option, which can be mitigated by the host via host.yaml settings. The default host settings allow for all of these locations to be enabled, but most to be forced filler. Feel free to reach out to me with any questions