### PR TITLE
Enable Turnipboy

### DIFF
--- a/turnipboy.toml
+++ b/turnipboy.toml
@@ -1,0 +1,9 @@
+name = "TurnipBoy"
+display_name = "Turnip Boy Commits Tax Evasion"
+home = "https://discord.com/channels/731205301247803413/1297617351977734214"
+default_url = "https://github.com/pointfivetee/TurnipBoyRandomizer/releases/download/v{{version}}/turnipboy.apworld"
+# Has outstanding client bug that prevented playing when receiving items in a certain order
+disabled = true
+
+[versions]
+"0.1.3" = {}


### PR DESCRIPTION
Is the apworld actually bugged? Or it was disabled due to the fact that the player gets bk for long periods of time?
From my experience, that's normal 