### PR TITLE
Oracle of Ages v0.5.1 Update

### DIFF
--- a/index/tloz_ooa.toml
+++ b/index/tloz_ooa.toml
@@ -1,6 +1,6 @@
 name = "The Legend of Zelda - Oracle of Ages"
-home = "https://discord.com/channels/731205301247803413/1279722186902601750"
+home = "https://discord.com/channels/731205301247803413/1492540520462024774"
 
 [versions]
-# https://discord.com/channels/731205301247803413/1279722186902601750/1394316324804497479
 "0.4.3+hotfix-0.6.2" = { local = "../apworlds/tloz_ooa-0.4.3+hotfix-0.6.2.apworld" }
+"0.5.1" = { url = "https://github.com/josephanimate2021/ArchipelagoOoA/releases/download/v0.5.1/tloz_ooa.apworld" }


### PR DESCRIPTION
## Summary of Changes
- Updated the `home` Discord URL to point to the new channel for the Oracle of Ages AP World
- Added version `0.5.1` of the OoA AP World

## Details

This update tracks the continued work by **Joseph** (`josephanimate2021` on GitHub) on the Oracle of Ages AP World. Joseph recently released version `0.5.0` and has already followed it up with `0.5.1`, which includes bug fixes on top of that initial release.

All credit for the AP World itself goes to Joseph — this PR simply keeps the index up to date with his latest release.

New release: https://github.com/josephanimate2021/ArchipelagoOoA/releases/tag/v0.5.1