### PR TITLE
Add GSTLA 0.2.3

### DIFF
--- a/index/gstla.toml
+++ b/index/gstla.toml
@@ -1,9 +1,6 @@
 name = "Golden Sun The Lost Age"
 home = "https://discord.com/channels/731205301247803413/1055515261270241320"
 default_url = "https://github.com/cjmang/Archipelago/releases/download/{{version}}/gstla.apworld"
-# Modifies placements in gen output. Has a bug that doesn't set back
-# location/item refs properly on top
-disabled = true
 
 [versions]
-"0.2.2-beta" = {}
+"0.2.3-beta" = {}


### PR DESCRIPTION
This version of GSTLA updates to not do sphere scaling in generate_output, but instead in stage_finalize_multiworld.

I ran the fuzzer with GSTLA and LM; no gen failures after this change.