### PR TITLE
Update Ratchet and Clank to v0.5.2

### DIFF
--- a/index/rac3.toml
+++ b/index/rac3.toml
@@ -6,3 +6,4 @@ default_url = "https://github.com/Taoshix/Archipelago-RaC3/releases/download/v{{
 [versions]
 "0.4.1" = {}
 "0.5.1" = {}
+"0.5.2" = {}


### PR DESCRIPTION
Sorry to bother you again. I felt these were important enough to warrent a v0.5.2 release
- Fixed a bug introduced in v0.5.1 that caused notifications to sometimes never show up when received inside of a menu
- Changed Phoenix Rescue warning from 8 seconds to 5
- Changed game name in manifest from RaC3 to Ratchet and Clank 3

Nothing in terms of generation has changed